### PR TITLE
PHP 7 capability

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -368,7 +368,7 @@ class WP_Object_Cache {
 		//error_log("Connection failure for $host:$port\n", 3, '/tmp/memcached.txt');
 	}
 
-	function WP_Object_Cache() {
+	function __construct() {
 		global $memcached_servers;
 
 		if ( isset($memcached_servers) )


### PR DESCRIPTION
The WP_Object_Cache class has a function with the same name. In PHP 7, its displaying a warning about this. I changed the name of the function to __construct to eliminate the warning.